### PR TITLE
feat: handle flow for a single blueprint cover

### DIFF
--- a/frontend/components/pages/BuildFormPage/build-form-page.styles.tsx
+++ b/frontend/components/pages/BuildFormPage/build-form-page.styles.tsx
@@ -85,7 +85,33 @@ export const PageFeedback = styled(Stacker)`
     color: ${COLOR.SUCCESS};
   }
 
+  &.is-optional {
+    color: ${COLOR.FADEDBLUE500};
+  }
+
   &.is-valid svg path {
     fill: ${COLOR.SUCCESS};
+  }
+`
+
+export const RenderedCovers = styled.div``
+
+export const RenderedCoversTitle = styled.h3`
+  ${getTypo(ETypo.FORM_LABEL)};
+  margin: 0 0 6px;
+`
+
+export const Rendered = styled.button`
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.5);
+
+  img {
+    display: block;
+  }
+
+  &.is-selected {
+    border: 2px solid ${COLOR.SELECTED};
   }
 `

--- a/frontend/components/pages/BuildFormPage/pager.component.tsx
+++ b/frontend/components/pages/BuildFormPage/pager.component.tsx
@@ -1,13 +1,14 @@
-import React from "react"
+import React, { useMemo } from "react"
 import cx from "classnames"
 import ThumbsUp from "../../../icons/thumbs-up"
 import Stacker from "../../ui/Stacker"
 import * as SC from "./build-form-page.styles"
 
-export type TPage = "data" | "cover"
+export type TPage = "data" | "cover" | "image"
 
 interface IPageState {
   isValid: boolean
+  optional?: boolean
 }
 
 interface IPageButton {
@@ -16,10 +17,27 @@ interface IPageButton {
   title: string
   isActive: boolean
   isValid: boolean
+  isOptional?: boolean
   onClick: (e: React.MouseEvent<HTMLDivElement>) => void
 }
 
 const PageButton = (props: IPageButton): JSX.Element => {
+  const status = useMemo(() => {
+    if (props.isOptional) {
+      return "Optional"
+    }
+
+    if (props.isValid) {
+      return (
+        <>
+          <ThumbsUp /> <span>Valid</span>
+        </>
+      )
+    }
+
+    return "Incomplete"
+  }, [props.isValid, props.isOptional])
+
   return (
     <SC.PageButton
       orientation="horizontal"
@@ -33,15 +51,12 @@ const PageButton = (props: IPageButton): JSX.Element => {
         <SC.PageFeedback
           orientation="horizontal"
           gutter={8}
-          className={cx({ "is-valid": props.isValid })}
+          className={cx({
+            "is-valid": props.isValid,
+            "is-optional": props.isOptional,
+          })}
         >
-          {props.isValid ? (
-            <>
-              <ThumbsUp /> <span>Valid</span>
-            </>
-          ) : (
-            "Incomplete"
-          )}
+          {status}
         </SC.PageFeedback>
       </SC.PageBody>
     </SC.PageButton>
@@ -64,6 +79,7 @@ const Pager: React.FC<IPagerProps> = (props) => {
           title="Data"
           isActive={props.currentPage === "data"}
           isValid={props.pagesState.data.isValid}
+          isOptional={props.pagesState.data.optional}
           onClick={() => props.goToPage("data")}
         />
         <PageButton
@@ -72,7 +88,17 @@ const Pager: React.FC<IPagerProps> = (props) => {
           title="Cover"
           isActive={props.currentPage === "cover"}
           isValid={props.pagesState.cover.isValid}
+          isOptional={props.pagesState.cover.optional}
           onClick={() => props.goToPage("cover")}
+        />
+        <PageButton
+          stateKey="image"
+          number={3}
+          title="Custom image"
+          isActive={props.currentPage === "image"}
+          isValid={props.pagesState.image.isValid}
+          isOptional={props.pagesState.image.optional}
+          onClick={() => props.goToPage("image")}
         />
       </Stacker>
     </SC.Row>

--- a/frontend/components/pages/BuildFormPage/step-1.component.tsx
+++ b/frontend/components/pages/BuildFormPage/step-1.component.tsx
@@ -5,7 +5,7 @@ import {
   IDecodedBlueprintBookData,
   IDecodedBlueprintData,
 } from "../../../types"
-import { ICreatePayloadResult } from "../../../types/models"
+import { ICreatePayloadResult, IFullPayload } from "../../../types/models"
 import {
   decodeBlueprint,
   isBlueprintItem,
@@ -55,7 +55,7 @@ type TStepState =
 
 interface IStep1Props {
   formikProps: FormikProps<IFormValues>
-  goToNextStep: () => void
+  goToNextStep: (payload: IFullPayload) => void
 }
 
 const Step1: React.FC<IStep1Props> = (props) => {
@@ -120,13 +120,14 @@ const Step1: React.FC<IStep1Props> = (props) => {
       ? stepState.json.blueprint_book
       : stepState.json.blueprint
 
+    props.formikProps.setFieldValue("isBook", stepState.isBook)
     props.formikProps.setFieldValue("title", bp.label)
     // TODO: set validity/availability of slug
     props.formikProps.setFieldValue("slug", res.data.extracted_slug.slug)
     props.formikProps.setFieldValue("description", bp.description || "")
     props.formikProps.setFieldValue("hash", res.data.payload.hash)
 
-    props.goToNextStep()
+    props.goToNextStep(res.data.payload)
   }
 
   function handleOnChange(e: React.ChangeEvent<HTMLTextAreaElement>): void {

--- a/frontend/components/pages/BuildFormPage/step-2-cover.component.tsx
+++ b/frontend/components/pages/BuildFormPage/step-2-cover.component.tsx
@@ -1,38 +1,70 @@
-import React from "react"
+import React /*{ useCallback }*/ from "react"
+// import cx from "classnames"
 import { FormikProps } from "formik"
-import ErrorMessage from "../../form/ErrorMessage"
-import ImageUpload from "../../ui/ImageUpload"
-import { IImageUpload } from "../../ui/ImageUpload/image-upload.component"
+import { IFullPayload } from "../../../types/models"
+import { isBook } from "../../../utils/build"
+import Stacker from "../../ui/Stacker"
 import { IFormValues } from "./build-form-page.component"
 import * as SC from "./build-form-page.styles"
 
 interface IStep2CoverProps {
   formikProps: FormikProps<IFormValues>
+  payloadData: IFullPayload
 }
 
 const Step2Cover: React.FC<IStep2CoverProps> = (props) => {
-  function onChangeImage(image: IImageUpload) {
-    props.formikProps.setFieldValue("cover.x", 0)
-    props.formikProps.setFieldValue("cover.y", 0)
-    props.formikProps.setFieldValue("cover.width", image.width)
-    props.formikProps.setFieldValue("cover.height", image.height)
-    props.formikProps.setFieldValue("cover.file", image.file)
-    props.formikProps.setFieldTouched("cover.file")
-  }
+  // function selectRenderedCover({ href, hash }: { href: string; hash: string }) {
+  //   props.formikProps.setFieldValue("cover.hash", hash)
+  //   props.formikProps.setFieldValue("cover.url", href)
+  //   props.formikProps.setFieldTouched("cover.hash")
+  // }
+
+  // const coverIsSelected = useCallback(
+  //   (hash: string) => props.formikProps.values.cover.hash === hash,
+  //   [props.formikProps.values.cover.hash]
+  // )
 
   return (
-    <SC.CoverWrapper>
-      <ImageUpload
-        label="Build image"
-        imageFile={props.formikProps.values.cover.file || null}
-        imageUrl={props.formikProps.values.cover.url || null}
-        onChange={onChangeImage}
-      />
-      {props.formikProps.touched.cover?.file &&
-        props.formikProps.errors.cover?.file && (
-          <ErrorMessage>{props.formikProps.errors.cover.file}</ErrorMessage>
-        )}
-    </SC.CoverWrapper>
+    <Stacker orientation="vertical" gutter={16}>
+      {isBook(props.payloadData) ? (
+        <p>
+          Select a generated render, or provide a custom image on the next step.
+        </p>
+      ) : (
+        <p>
+          This generated render will be used. Optionally, a custom image can be
+          provided on the next step.
+        </p>
+      )}
+
+      <Stacker orientation="horizontal">
+        <SC.RenderedCovers>
+          <SC.RenderedCoversTitle>Rendered blueprint</SC.RenderedCoversTitle>
+          {isBook(props.payloadData) ? (
+            <div>todo..</div>
+          ) : (
+            <SC.Rendered
+              // className={cx({
+              //   "is-selected": coverIsSelected(props.payloadData.hash),
+              // })}
+              type="button"
+              // onClick={() =>
+              //   selectRenderedCover({
+              //     href: props.payloadData._links.rendering_thumb
+              //       ?.href as string,
+              //     hash: props.payloadData.hash,
+              //   })
+              // }
+            >
+              <img
+                src={props.payloadData._links.rendering_thumb?.href}
+                alt=""
+              />
+            </SC.Rendered>
+          )}
+        </SC.RenderedCovers>
+      </Stacker>
+    </Stacker>
   )
 }
 

--- a/frontend/components/pages/BuildFormPage/step-2-image.component.tsx
+++ b/frontend/components/pages/BuildFormPage/step-2-image.component.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import { FormikProps } from "formik"
+import ErrorMessage from "../../form/ErrorMessage"
+import ImageUpload from "../../ui/ImageUpload"
+import { IImageUpload } from "../../ui/ImageUpload/image-upload.component"
+import Stacker from "../../ui/Stacker"
+import { IFormValues } from "./build-form-page.component"
+import * as SC from "./build-form-page.styles"
+
+interface IStep2CoverProps {
+  formikProps: FormikProps<IFormValues>
+}
+
+const Step2Image: React.FC<IStep2CoverProps> = (props) => {
+  function onChangeImage(image: IImageUpload) {
+    props.formikProps.setFieldValue("cover.x", 0)
+    props.formikProps.setFieldValue("cover.y", 0)
+    props.formikProps.setFieldValue("cover.width", image.width)
+    props.formikProps.setFieldValue("cover.height", image.height)
+    props.formikProps.setFieldValue("cover.file", image.file)
+    props.formikProps.setFieldTouched("cover.file")
+  }
+
+  return (
+    <Stacker orientation="vertical" gutter={16}>
+      <p>asdf</p>
+
+      <SC.CoverWrapper>
+        <ImageUpload
+          label="Build image"
+          imageFile={props.formikProps.values.cover.file || null}
+          imageUrl={props.formikProps.values.cover.url || null}
+          onChange={onChangeImage}
+        />
+        {props.formikProps.touched.cover?.file &&
+          props.formikProps.errors.cover?.file && (
+            <ErrorMessage>{props.formikProps.errors.cover.file}</ErrorMessage>
+          )}
+      </SC.CoverWrapper>
+    </Stacker>
+  )
+}
+
+export default Step2Image

--- a/frontend/components/pages/BuildFormPage/step-2.component.tsx
+++ b/frontend/components/pages/BuildFormPage/step-2.component.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react"
 import { FormikProps } from "formik"
+import { IFullPayload } from "../../../types/models"
 import Button from "../../ui/Button"
 import Spinner from "../../ui/Spinner"
 import Stacker from "../../ui/Stacker"
@@ -9,10 +10,12 @@ import Pager from "./pager.component"
 import { TPage } from "./pager.component"
 import Step2Cover from "./step-2-cover.component"
 import Step2Data from "./step-2-data.component"
+import Step2Image from "./step-2-image.component"
 
 interface IStep2Props {
   formikProps: FormikProps<IFormValues>
   submitStatus: { loading: boolean; error: boolean | string }
+  payloadData: IFullPayload
 }
 
 const Step2: React.FC<IStep2Props> = (props) => {
@@ -50,12 +53,22 @@ const Step2: React.FC<IStep2Props> = (props) => {
                 ]).isValid,
               },
               cover: { isValid: validateFields(["cover"]).isValid },
+              image: {
+                isValid: validateFields(["cover"]).isValid,
+                optional: true,
+              },
             }}
             goToPage={setPage}
           />
 
           {page === "data" && <Step2Data formikProps={props.formikProps} />}
-          {page === "cover" && <Step2Cover formikProps={props.formikProps} />}
+          {page === "cover" && (
+            <Step2Cover
+              formikProps={props.formikProps}
+              payloadData={props.payloadData}
+            />
+          )}
+          {page === "image" && <Step2Image formikProps={props.formikProps} />}
 
           <SC.ButtonsStack gutter={24} orientation="horizontal">
             <Button


### PR DESCRIPTION
This moves the flow to a 3 step flow that's necessary for blueprint books.

Book flow still to do in a follow-up PR.

![image](https://user-images.githubusercontent.com/3461986/108256884-09b09800-712c-11eb-8a78-c66a77f78a5d.png)
