### PR TITLE
add `DELETE {hash}/rendering`

### DIFF
--- a/backend/src/FactorioTech.Api/Controllers/PayloadController.cs
+++ b/backend/src/FactorioTech.Api/Controllers/PayloadController.cs
@@ -146,6 +146,20 @@ namespace FactorioTech.Api.Controllers
         }
 
         /// <summary>
+        /// Delete the renderings of all types for this payload
+        /// </summary>
+        /// <param name="hash" example="f8283ab0085a7e31c0ad3c43db36ae87">The hash of the desired payload</param>
+        /// <response code="204">The renderings have been deleted or do not exist</response>
+        [Authorize(Roles = Role.Administrator)]
+        [HttpDelete("{hash}/rendering")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        public IActionResult DeleteRendering([Required]Hash hash)
+        {
+            _imageService.DeleteRendering(hash);
+            return NoContent();
+        }
+
+        /// <summary>
         /// Create a payload for the encoded blueprint string. If the blueprint is a `blueprint-book`,
         /// payloads for all children will be created too.
         /// </summary>

--- a/backend/src/FactorioTech.Api/Controllers/PayloadController.cs
+++ b/backend/src/FactorioTech.Api/Controllers/PayloadController.cs
@@ -8,11 +8,8 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.Extensions.Logging;
 using SluggyUnidecode;
-using System;
 using System.ComponentModel.DataAnnotations;
-using System.Diagnostics;
 using System.Linq;
 using System.Net.Mime;
 using System.Threading.Tasks;
@@ -24,10 +21,7 @@ namespace FactorioTech.Api.Controllers
     public class PayloadController : ControllerBase
     {
         private const int OneMonthInSeconds = 2629800;
-        private static readonly TimeSpan NewRenderingLoadInterval = TimeSpan.FromSeconds(2);
-        private static readonly TimeSpan NewRenderingLoadTimeout = TimeSpan.FromSeconds(30);
 
-        private readonly ILogger<PayloadController> _logger;
         private readonly AppDbContext _dbContext;
         private readonly ImageService _imageService;
         private readonly BuildService _buildService;
@@ -35,14 +29,12 @@ namespace FactorioTech.Api.Controllers
         private readonly SlugService _slugService;
 
         public PayloadController(
-            ILogger<PayloadController> logger,
             AppDbContext dbContext,
             ImageService imageService,
             BuildService buildService,
             BlueprintConverter blueprintConverter,
             SlugService slugService)
         {
-            _logger = logger;
             _dbContext = dbContext;
             _imageService = imageService;
             _buildService = buildService;
@@ -128,20 +120,10 @@ namespace FactorioTech.Api.Controllers
         [ResponseCache(Duration = OneMonthInSeconds, Location = ResponseCacheLocation.Any)]
         public async Task<IActionResult> GetRendering([Required]Hash hash, [Required]ImageService.RenderingType type)
         {
-            var sw = Stopwatch.StartNew();
+            var file = await _imageService.TryLoadRendering(hash, type);
+            if (file != null)
+                return File(file, "image/png");
 
-            do
-            {
-                var file = await _imageService.TryLoadRendering(hash, type);
-                if (file != null)
-                    return File(file, "image/png");
-
-                _logger.LogWarning("Rendering {Type} for {Hash} not found; will retry in {Interval}", type, hash, NewRenderingLoadInterval);
-                await Task.Delay(NewRenderingLoadInterval);
-            }
-            while (sw.Elapsed < NewRenderingLoadTimeout);
-
-            _logger.LogWarning("Rendering {Type} for {Hash} not found after {Timeout}; giving up", type, hash, NewRenderingLoadTimeout);
             return NotFound();
         }
 

--- a/backend/src/FactorioTech.Api/Services/LinkBuilder.cs
+++ b/backend/src/FactorioTech.Api/Services/LinkBuilder.cs
@@ -5,6 +5,7 @@ using FactorioTech.Core.Domain;
 using FactorioTech.Core.Services;
 using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
+using System.Net.Http;
 
 namespace FactorioTech.Api.Services
 {
@@ -14,11 +15,11 @@ namespace FactorioTech.Api.Services
             new()
             {
                 CreateBuild = urlHelper.ActionContext.HttpContext.User.Identity?.IsAuthenticated == true
-                    ? new(urlHelper.ActionLink(nameof(BuildController.CreateBuild), "Build"), "post")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.CreateBuild), "Build"), HttpMethod.Post)
                     : null,
 
                 CreatePayload = urlHelper.ActionContext.HttpContext.User.Identity?.IsAuthenticated == true
-                    ? new(urlHelper.ActionLink(nameof(PayloadController.CreatePayload), "Payload"), "put")
+                    ? new(urlHelper.ActionLink(nameof(PayloadController.CreatePayload), "Payload"), HttpMethod.Put)
                     : null,
 
                 Prev = query.Page > 1
@@ -52,15 +53,15 @@ namespace FactorioTech.Api.Services
                 Followers = new (urlHelper.ActionLink(nameof(BuildController.GetFollowers), "Build", buildValues), build.FollowerCount),
 
                 AddVersion = urlHelper.ActionContext.HttpContext.User.CanAddVersion(build)
-                    ? new(urlHelper.ActionLink(nameof(BuildController.GetVersions), "Build", buildValues), "post")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.GetVersions), "Build", buildValues), HttpMethod.Post)
                     : null,
 
                 Edit = urlHelper.ActionContext.HttpContext.User.CanEdit(build)
-                    ? new(urlHelper.ActionLink(nameof(BuildController.EditDetails), "Build", buildValues), "patch")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.EditDetails), "Build", buildValues), HttpMethod.Patch)
                     : null,
 
                 Delete = urlHelper.ActionContext.HttpContext.User.CanDelete(build)
-                    ? new(urlHelper.ActionLink(nameof(BuildController.DeleteBuild), "Build", buildValues), "delete")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.DeleteBuild), "Build", buildValues), HttpMethod.Delete)
                     : null,
             };
         }
@@ -87,23 +88,23 @@ namespace FactorioTech.Api.Services
                 Followers = new (urlHelper.ActionLink(nameof(BuildController.GetFollowers), "Build", buildValues), build.FollowerCount),
 
                 AddFavorite = urlHelper.ActionContext.HttpContext.User.Identity?.IsAuthenticated == true && currentUserIsFollower == false
-                    ? new(urlHelper.ActionLink(nameof(BuildController.AddFavorite), "Build", buildValues), "put")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.AddFavorite), "Build", buildValues), HttpMethod.Put)
                     : null,
 
                 RemoveFavorite = urlHelper.ActionContext.HttpContext.User.Identity?.IsAuthenticated == true && currentUserIsFollower
-                    ? new(urlHelper.ActionLink(nameof(BuildController.RemoveFavorite), "Build", buildValues), "delete")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.RemoveFavorite), "Build", buildValues), HttpMethod.Delete)
                     : null,
 
                 AddVersion = urlHelper.ActionContext.HttpContext.User.CanAddVersion(build)
-                    ? new(urlHelper.ActionLink(nameof(BuildController.GetVersions), "Build", buildValues), "post")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.GetVersions), "Build", buildValues), HttpMethod.Post)
                     : null,
 
                 Edit = urlHelper.ActionContext.HttpContext.User.CanEdit(build)
-                    ? new(urlHelper.ActionLink(nameof(BuildController.EditDetails), "Build", buildValues), "patch")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.EditDetails), "Build", buildValues), HttpMethod.Patch)
                     : null,
 
                 Delete = urlHelper.ActionContext.HttpContext.User.CanDelete(build)
-                    ? new(urlHelper.ActionLink(nameof(BuildController.DeleteBuild), "Build", buildValues), "delete")
+                    ? new(urlHelper.ActionLink(nameof(BuildController.DeleteBuild), "Build", buildValues), HttpMethod.Delete)
                     : null,
             };
         }
@@ -146,6 +147,10 @@ namespace FactorioTech.Api.Services
                         hash = payload.Hash,
                         type = ImageService.RenderingType.Thumb.ToString().ToLowerInvariant(),
                     }))
+                    : null,
+
+                DeleteRendering = envelope.Blueprint != null && urlHelper.ActionContext.HttpContext.User.CanDeleteRendering(payload)
+                    ? new(urlHelper.ActionLink(nameof(PayloadController.DeleteRendering), "Payload", new { hash = payload.Hash, }), HttpMethod.Delete)
                     : null,
             };
     }

--- a/backend/src/FactorioTech.Api/ViewModels/PayloadModel.cs
+++ b/backend/src/FactorioTech.Api/ViewModels/PayloadModel.cs
@@ -34,6 +34,13 @@ namespace FactorioTech.Api.ViewModels
         /// Only available if the payload is of type `blueprint`.
         /// </summary>
         public LinkModel? RenderingThumb { get; init; }
+
+        /// <summary>
+        /// The absolute URL of the API endpoint to delete this payload's renderings.
+        /// Only available if the call has been made with an authenticated user token
+        /// and the authenticated user has the required permissions.
+        /// </summary>
+        public LinkModel? DeleteRendering { get; init; }
     }
 
     [SwaggerDiscriminator("type")]

--- a/backend/src/FactorioTech.Api/ViewModels/ViewModelBase.cs
+++ b/backend/src/FactorioTech.Api/ViewModels/ViewModelBase.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Net.Http;
 using System.Text.Json.Serialization;
 
 namespace FactorioTech.Api.ViewModels
@@ -16,18 +17,18 @@ namespace FactorioTech.Api.ViewModels
         /// The absolute URL of the linked resource.
         /// </summary>
         [Required]
-        public string Href { get; set; }
+        public string Href { get; }
 
         /// <summary>
         /// The HTTP method to request the linked resource.
         /// Defaults to `GET` if unset (`null`).
         /// </summary>
-        public string? Method { get; set; }
+        public string? Method { get; }
 
-        public LinkModel(string href, string? method = null)
+        public LinkModel(string href, HttpMethod? method = null)
         {
             Href = href;
-            Method = method?.ToLowerInvariant();
+            Method = method?.Method;
         }
     }
 

--- a/backend/src/FactorioTech.Core/IdentityExtensions.cs
+++ b/backend/src/FactorioTech.Core/IdentityExtensions.cs
@@ -29,5 +29,8 @@ namespace FactorioTech.Core
 
         public static bool CanDelete(this ClaimsPrincipal principal, Build build) =>
             principal.IsInRole(Role.Administrator);
+
+        public static bool CanDeleteRendering(this ClaimsPrincipal principal, Payload payload) =>
+            principal.IsInRole(Role.Administrator);
     }
 }

--- a/backend/src/FactorioTech.Core/Services/ImageService.cs
+++ b/backend/src/FactorioTech.Core/Services/ImageService.cs
@@ -168,6 +168,20 @@ namespace FactorioTech.Core.Services
             }
         }
 
+        public void DeleteRendering(Hash hash)
+        {
+            var types = new[] { RenderingType.Full, RenderingType.Thumb };
+            foreach (var type in types)
+            {
+                var path = GetRenderingFqfn(hash, type);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                    _logger.LogInformation("Deleted rendering {Type} for {Hash}", type, hash);
+                }
+            }
+        }
+
         public async Task SaveRenderingThumb(Hash hash, Stream rendering)
         {
             var (image, format) = await Image.LoadWithFormatAsync(rendering);

--- a/frontend/types/generated-api.ts
+++ b/frontend/types/generated-api.ts
@@ -509,6 +509,24 @@ export interface paths {
       }
     }
   }
+  "/payloads/{hash}/rendering": {
+    delete: {
+      parameters: {
+        path: {
+          /** The hash of the desired payload */
+          hash: string
+        }
+      }
+      responses: {
+        /** The renderings have been deleted or do not exist */
+        204: never
+        /** Unauthorized */
+        401: unknown
+        /** Forbidden */
+        403: unknown
+      }
+    }
+  }
   "/payloads": {
     put: {
       responses: {
@@ -1020,6 +1038,12 @@ export interface components {
        * Only available if the payload is of type `blueprint`.
        */
       rendering_thumb?: components["schemas"]["LinkModel"] | null
+      /**
+       * The absolute URL of the API endpoint to delete this payload's renderings.
+       * Only available if the call has been made with an authenticated user token
+       * and the authenticated user has the required permissions.
+       */
+      delete_rendering?: components["schemas"]["LinkModel"] | null
     }
     PayloadModelBase: {
       /** The payload's blueprint type. */


### PR DESCRIPTION
@veksen ideally you could add a button/icon to delete renderings at some point. for now I'm just using this API to delete dodgy renderings manually