### PR TITLE
ui: improve responsiveness on header

### DIFF
--- a/frontend/components/ui/Header/header.component.tsx
+++ b/frontend/components/ui/Header/header.component.tsx
@@ -46,11 +46,17 @@ function Header(): JSX.Element {
         </Link>
 
         <SC.StyledStacker orientation="horizontal" gutter={18}>
-          {user && (
-            <Link href="/build/create">
-              <SC.CreateBuildButton>Add a build</SC.CreateBuildButton>
-            </Link>
-          )}
+          <Media greaterThanOrEqual="sm">
+            {(mcx, renderChildren) => {
+              return renderChildren && user ? (
+                <Link href="/build/create">
+                  <SC.CreateBuildButton className={mcx}>
+                    Add a build
+                  </SC.CreateBuildButton>
+                </Link>
+              ) : null
+            }}
+          </Media>
 
           {!user && (
             <Link href="/api/login" passHref>

--- a/frontend/components/ui/UserDropdown/user-dropdown.component.tsx
+++ b/frontend/components/ui/UserDropdown/user-dropdown.component.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react"
 import cx from "classnames"
 import Link from "next/link"
+import { Media } from "../../../design/styles/media"
 import Caret from "../../../icons/caret"
 import { IStoreUser } from "../../../types/models"
 import Avatar from "../Avatar"
@@ -18,7 +19,13 @@ function UserDropdown(props: IUserDropdownProps): JSX.Element {
       <SC.Dropdown>
         <SC.User onClick={() => setOpen((prev) => !prev)}>
           <Avatar username={props.user.username} size="medium" />
-          <span>{props.user.username}</span>
+          <Media greaterThanOrEqual="sm">
+            {(mcx, renderChildren) => {
+              return renderChildren ? (
+                <span className={mcx}>{props.user.username}</span>
+              ) : null
+            }}
+          </Media>
           <Caret />
         </SC.User>
         <SC.DropdownContent>


### PR DESCRIPTION
- Hides the add build button on mobile (it doesn't make much sense in the first place, how do you get your blueprint string?)
- Hides the username as it simply doesn't fit

![image](https://user-images.githubusercontent.com/3461986/110237047-b306d480-7f07-11eb-88a6-337079e6a0f1.png)
