### PR TITLE
feat: move view in editor button for books

### DIFF
--- a/frontend/components/pages/BuildPage/build-page.styles.tsx
+++ b/frontend/components/pages/BuildPage/build-page.styles.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components"
 import { getTypo } from "../../../design/helpers/typo"
 import { COLOR } from "../../../design/tokens/color"
 import { ETypo } from "../../../design/tokens/typo"
-import { ButtonWrapper } from "../../ui/Button/button.styles"
 import Stacker from "../../ui/Stacker"
 
 export const BuildImage = styled.div`
@@ -182,12 +181,6 @@ export const TabWrapper = styled.div`
 
   & > :last-child {
     margin-bottom: 0;
-  }
-
-  // TODO: remove, temporary
-  & ${ButtonWrapper} {
-    align-self: flex-start;
-    margin-bottom: 16px;
   }
 
   &.is-active {

--- a/frontend/components/pages/BuildPage/tabs/blueprints-tab.component.tsx
+++ b/frontend/components/pages/BuildPage/tabs/blueprints-tab.component.tsx
@@ -39,6 +39,7 @@ const BlueprintsTab: TTabComponent = (props) => {
                   icons={bp.icons}
                   description={bp.description}
                   image={bp._links?.rendering_thumb}
+                  raw={bp._links?.raw}
                   entities={bp.entities}
                   tiles={bp.tiles}
                 />

--- a/frontend/components/ui/BlueprintItem/blueprint-item.component.tsx
+++ b/frontend/components/ui/BlueprintItem/blueprint-item.component.tsx
@@ -1,11 +1,14 @@
 import React, { useCallback, useState } from "react"
 import cx from "classnames"
+import Link from "next/link"
 import useImage from "../../../hooks/useImage"
 import Caret from "../../../icons/caret"
+import Editor from "../../../icons/editor"
 import { IBlueprintPayload, IFullPayload } from "../../../types/models"
 import { countEntities, isBook } from "../../../utils/build"
 import BlueprintRequiredItems from "../BlueprintRequiredItems"
 import BuildIcon from "../BuildIcon"
+import Button from "../Button"
 import Spinner from "../Spinner"
 import Stacker from "../Stacker"
 import WithIcons from "../WithIcons"
@@ -32,6 +35,7 @@ interface IBlueprintItemPropsBlueprint extends IBaseBlueprintItemProps {
   tiles: IBlueprintPayload["tiles"]
   children?: React.ReactNode
   highlighted?: boolean
+  raw?: IFullPayload["_links"]["raw"]
 }
 
 type IBlueprintItemProps =
@@ -105,41 +109,56 @@ function BlueprintItem(props: IBlueprintItemProps): JSX.Element {
             )}
           </SC.Title>
           {expanded && (props.image || props.description) && (
-            <SC.Info>
-              {props.image && (
-                <SC.ImageWrapper>
-                  {imageIsLoaded ? (
-                    <img src={props.image.href} alt="" width={200} />
-                  ) : (
-                    <SC.SpinnerWrapper>
-                      <Spinner />
-                    </SC.SpinnerWrapper>
+            <>
+              <SC.Buttons>
+                {!props.isBook && props.raw && (
+                  <Link
+                    href={`https://fbe.teoxoy.com/?source=${props.raw.href}`}
+                    passHref
+                  >
+                    <Button as="a" variant="default" size="small">
+                      <Editor />
+                      View in editor
+                    </Button>
+                  </Link>
+                )}
+              </SC.Buttons>
+              <SC.Info>
+                {props.image && (
+                  <SC.ImageWrapper>
+                    {imageIsLoaded ? (
+                      <img src={props.image.href} alt="" width={200} />
+                    ) : (
+                      <SC.SpinnerWrapper>
+                        <Spinner />
+                      </SC.SpinnerWrapper>
+                    )}
+                  </SC.ImageWrapper>
+                )}
+                <SC.InnerContent orientation="vertical" gutter={16}>
+                  {props.description && (
+                    <SC.Description>
+                      {props.description.split("\n").map((text) => (
+                        <>
+                          {text}
+                          <br />
+                        </>
+                      ))}
+                    </SC.Description>
                   )}
-                </SC.ImageWrapper>
-              )}
-              <SC.InnerContent orientation="vertical" gutter={16}>
-                {props.description && (
-                  <SC.Description>
-                    {props.description.split("\n").map((text) => (
-                      <>
-                        {text}
-                        <br />
-                      </>
-                    ))}
-                  </SC.Description>
-                )}
-                {!props.isBook && (props.entities || props.tiles) && (
-                  <SC.RequiredItems>
-                    <SC.Subtitle>Required items</SC.Subtitle>
-                    <BlueprintRequiredItems
-                      entities={props.entities}
-                      tiles={props.tiles}
-                    />
-                  </SC.RequiredItems>
-                )}
-                {props.children}
-              </SC.InnerContent>
-            </SC.Info>
+                  {!props.isBook && (props.entities || props.tiles) && (
+                    <SC.RequiredItems>
+                      <SC.Subtitle>Required items</SC.Subtitle>
+                      <BlueprintRequiredItems
+                        entities={props.entities}
+                        tiles={props.tiles}
+                      />
+                    </SC.RequiredItems>
+                  )}
+                  {props.children}
+                </SC.InnerContent>
+              </SC.Info>
+            </>
           )}
         </SC.Content>
       </SC.BlueprintItemInner>
@@ -171,6 +190,7 @@ function BlueprintItem(props: IBlueprintItemProps): JSX.Element {
                   icons={node.icons}
                   description={node.description}
                   image={node._links.rendering_thumb}
+                  raw={node._links.raw}
                   entities={node.entities}
                   tiles={node.tiles}
                 />

--- a/frontend/components/ui/BlueprintItem/blueprint-item.styles.tsx
+++ b/frontend/components/ui/BlueprintItem/blueprint-item.styles.tsx
@@ -45,6 +45,11 @@ export const Content = styled.div`
   }
 `
 
+export const Buttons = styled.div`
+  margin-top: 16px;
+  display: flex;
+`
+
 export const Info = styled.div`
   display: flex;
   gap: 16px;

--- a/frontend/components/ui/BuildHeader/build-header.component.tsx
+++ b/frontend/components/ui/BuildHeader/build-header.component.tsx
@@ -89,20 +89,22 @@ function Buildheader(props: IBuildheader): JSX.Element {
                   Raw
                 </Button>
               </Link>
-              <Link
-                href={`https://fbe.teoxoy.com/?source=${props.payload.data?._links.raw.href}`}
-                passHref
-              >
-                <Button
-                  as="a"
-                  variant="default"
-                  size="small"
-                  disabled={!props.payload.data}
+              {props.build.latest_type === "blueprint" && (
+                <Link
+                  href={`https://fbe.teoxoy.com/?source=${props.payload.data?._links.raw.href}`}
+                  passHref
                 >
-                  <Editor />
-                  View in editor
-                </Button>
-              </Link>
+                  <Button
+                    as="a"
+                    variant="default"
+                    size="small"
+                    disabled={!props.payload.data}
+                  >
+                    <Editor />
+                    View in editor
+                  </Button>
+                </Link>
+              )}
               <CopyStringToClipboard
                 toCopy={props.build.latest_version.payload.encoded}
                 variant="cta"


### PR DESCRIPTION
Moves the (invalid) "View in blueprint" button to blueprint items, for books.

![image](https://user-images.githubusercontent.com/3461986/111927788-4c95c080-8a88-11eb-8855-5769035be07e.png)
