### PR TITLE
fix: normalize blueprint item behavior across context

### DIFF
--- a/frontend/components/pages/BuildFormPage/build-form-page.styles.tsx
+++ b/frontend/components/pages/BuildFormPage/build-form-page.styles.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components"
 import { getTypo } from "../../../design/helpers/typo"
 import { COLOR } from "../../../design/tokens/color"
 import { ETypo } from "../../../design/tokens/typo"
-import Button from "../../ui/Button"
 import Stacker from "../../ui/Stacker"
 
 export const Content = styled.div``
@@ -149,11 +148,6 @@ export const InputHint = styled.div`
 `
 
 export const RenderedCovers = styled.div``
-
-export const SelectRenderButton = styled(Button)`
-  margin-top: 8px;
-  align-self: flex-end;
-`
 
 export const Rendered = styled.div`
   border-radius: 4px;

--- a/frontend/components/pages/BuildFormPage/step-2-cover.component.tsx
+++ b/frontend/components/pages/BuildFormPage/step-2-cover.component.tsx
@@ -1,10 +1,10 @@
-import React, { useCallback } from "react"
+import React from "react"
 import { FormikProps } from "formik"
-import { IBlueprintPayload, IFullPayload } from "../../../types/models"
+import { IFullPayload } from "../../../types/models"
 import { isBook } from "../../../utils/build"
 import ErrorMessage from "../../form/ErrorMessage"
 import Radio from "../../form/Radio"
-import BlueprintItem from "../../ui/BlueprintItem"
+import BlueprintItemExplorer from "../../ui/BlueprintItemExplorer"
 import ImageUpload from "../../ui/ImageUpload"
 import { IImageUpload } from "../../ui/ImageUpload/image-upload.component"
 import Stacker from "../../ui/Stacker"
@@ -27,15 +27,13 @@ const Step2Cover: React.FC<IStep2CoverProps> = (props) => {
     props.formikProps.setFieldTouched("cover.file")
   }
 
-  function selectRenderedCover(e: React.MouseEvent, bp: IBlueprintPayload) {
+  function selectRenderedCover(
+    e: React.MouseEvent,
+    hash: IFullPayload["hash"]
+  ) {
     e.stopPropagation()
-    props.formikProps.setFieldValue("cover.hash", bp.hash)
+    props.formikProps.setFieldValue("cover.hash", hash)
   }
-
-  const coverIsSelected = useCallback(
-    (hash: string) => props.formikProps.values.cover.hash === hash,
-    [props.formikProps.values.cover.hash]
-  )
 
   return (
     <Stacker orientation="vertical" gutter={16}>
@@ -91,47 +89,13 @@ const Step2Cover: React.FC<IStep2CoverProps> = (props) => {
           <SC.RenderedCovers>
             {isBook(props.payloadData) ? (
               <div>
-                {props.payloadData.children.map((bp) => {
-                  if (isBook(bp)) {
-                    return (
-                      <BlueprintItem
-                        key={bp.hash}
-                        depth={0}
-                        isBook={true}
-                        title={bp.label}
-                        icons={bp.icons}
-                        description={bp.description}
-                        image={bp._links?.rendering_thumb}
-                        nodes={bp.children}
-                      />
-                    )
-                  }
-
-                  return (
-                    <BlueprintItem
-                      key={bp.hash}
-                      depth={0}
-                      isBook={false}
-                      title={bp.label}
-                      icons={bp.icons}
-                      description={bp.description}
-                      image={bp._links?.rendering_thumb}
-                      entities={bp.entities}
-                      tiles={bp.tiles}
-                      highlighted={coverIsSelected(bp.hash)}
-                    >
-                      <SC.SelectRenderButton
-                        variant="alt"
-                        type="button"
-                        onClick={(e) => {
-                          selectRenderedCover(e, bp)
-                        }}
-                      >
-                        Select render
-                      </SC.SelectRenderButton>
-                    </BlueprintItem>
-                  )
-                })}
+                <BlueprintItemExplorer
+                  type="selectable"
+                  onSelect={selectRenderedCover}
+                  selectedHash={props.formikProps.values.cover.hash}
+                >
+                  {props.payloadData.children}
+                </BlueprintItemExplorer>
               </div>
             ) : (
               <SC.Rendered>

--- a/frontend/components/pages/BuildPage/tabs/blueprints-tab.component.tsx
+++ b/frontend/components/pages/BuildPage/tabs/blueprints-tab.component.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 import { isBook } from "../../../../utils/build"
-import BlueprintItem from "../../../ui/BlueprintItem"
+import BlueprintItemExplorer from "../../../ui/BlueprintItemExplorer"
 import { TTabComponent } from "../tabs.component"
 import Tab from "./tab.component"
 
@@ -14,38 +14,9 @@ const BlueprintsTab: TTabComponent = (props) => {
         isBook(props.payload.data) &&
         isBook(props.build.latest_version.payload) && (
           <>
-            {props.payload.data.children.map((bp) => {
-              if (isBook(bp)) {
-                return (
-                  <BlueprintItem
-                    key={bp.hash}
-                    depth={0}
-                    isBook={true}
-                    title={bp.label}
-                    icons={bp.icons}
-                    description={bp.description}
-                    image={bp._links?.rendering_thumb}
-                    nodes={bp.children}
-                  />
-                )
-              }
-
-              return (
-                <BlueprintItem
-                  key={bp.hash}
-                  depth={0}
-                  isBook={false}
-                  title={bp.label}
-                  icons={bp.icons}
-                  description={bp.description}
-                  image={bp._links?.rendering_thumb}
-                  raw={bp._links?.raw}
-                  encoded={bp.encoded}
-                  entities={bp.entities}
-                  tiles={bp.tiles}
-                />
-              )
-            })}
+            <BlueprintItemExplorer type="readOnly">
+              {props.payload.data.children}
+            </BlueprintItemExplorer>
           </>
         )}
     </Tab>

--- a/frontend/components/ui/BlueprintItem/blueprint-item.component.tsx
+++ b/frontend/components/ui/BlueprintItem/blueprint-item.component.tsx
@@ -148,36 +148,38 @@ function BlueprintItem(props: IBlueprintItemProps): JSX.Element {
           </SC.Title>
           {expanded && (props.image || props.description) && (
             <>
-              {!props.isBook && (props.raw || props.encoded) && (
-                <SC.Buttons>
-                  {!props.isBook && props.raw && (
-                    <Link href={props.raw.href} passHref>
-                      <Button as="a" variant="default" size="small">
-                        <Raw />
-                        Raw
-                      </Button>
-                    </Link>
-                  )}
-                  {!props.isBook && props.raw && (
-                    <Link
-                      href={`https://fbe.teoxoy.com/?source=${props.raw.href}`}
-                      passHref
-                    >
-                      <Button as="a" variant="default" size="small">
-                        <Editor />
-                        View in editor
-                      </Button>
-                    </Link>
-                  )}
-                  {!props.isBook && props.encoded && (
-                    <CopyStringToClipboard
-                      toCopy={props.encoded}
-                      variant="cta"
-                      size="small"
-                    />
-                  )}
-                </SC.Buttons>
-              )}
+              {!props.isBook &&
+                bpItemExplorer.type === "readOnly" &&
+                (props.raw || props.encoded) && (
+                  <SC.Buttons>
+                    {!props.isBook && props.raw && (
+                      <Link href={props.raw.href} passHref>
+                        <Button as="a" variant="default" size="small">
+                          <Raw />
+                          Raw
+                        </Button>
+                      </Link>
+                    )}
+                    {!props.isBook && props.raw && (
+                      <Link
+                        href={`https://fbe.teoxoy.com/?source=${props.raw.href}`}
+                        passHref
+                      >
+                        <Button as="a" variant="default" size="small">
+                          <Editor />
+                          View in editor
+                        </Button>
+                      </Link>
+                    )}
+                    {!props.isBook && props.encoded && (
+                      <CopyStringToClipboard
+                        toCopy={props.encoded}
+                        variant="cta"
+                        size="small"
+                      />
+                    )}
+                  </SC.Buttons>
+                )}
               {props.image && zoomedImage && (
                 <SC.ZoomedImage>{renderImage()}</SC.ZoomedImage>
               )}

--- a/frontend/components/ui/BlueprintItem/blueprint-item.component.tsx
+++ b/frontend/components/ui/BlueprintItem/blueprint-item.component.tsx
@@ -9,6 +9,7 @@ import Editor from "../../../icons/editor"
 import Raw from "../../../icons/raw"
 import { IBlueprintPayload, IFullPayload } from "../../../types/models"
 import { countEntities, isBook } from "../../../utils/build"
+import { useBlueprintItemExplorer } from "../BlueprintItemExplorer/blueprint-item-explorer.provider"
 import BlueprintRequiredItems from "../BlueprintRequiredItems"
 import BuildIcon from "../BuildIcon"
 import Button from "../Button"
@@ -19,6 +20,7 @@ import WithIcons from "../WithIcons"
 import * as SC from "./blueprint-item.styles"
 
 interface IBaseBlueprintItemProps {
+  hash: IFullPayload["hash"]
   depth: number
   isBook: boolean
   title: IFullPayload["label"]
@@ -38,7 +40,6 @@ interface IBlueprintItemPropsBlueprint extends IBaseBlueprintItemProps {
   entities: IBlueprintPayload["entities"]
   tiles: IBlueprintPayload["tiles"]
   children?: React.ReactNode
-  highlighted?: boolean
   raw?: IFullPayload["_links"]["raw"]
   encoded?: IFullPayload["encoded"]
 }
@@ -48,6 +49,7 @@ type IBlueprintItemProps =
   | IBlueprintItemPropsBlueprint
 
 function BlueprintItem(props: IBlueprintItemProps): JSX.Element {
+  const bpItemExplorer = useBlueprintItemExplorer()
   const [expanded, setExpanded] = useState(false)
   const [zoomedImage, toggleZoomedImage] = useToggle(false)
   const { loaded: imageIsLoaded } = useImage(props.image?.href)
@@ -120,7 +122,10 @@ function BlueprintItem(props: IBlueprintItemProps): JSX.Element {
       depth={props.depth}
       className={cx({
         "is-expanded": expanded,
-        "is-highlighted": !props.isBook && props.highlighted,
+        "is-highlighted":
+          !props.isBook &&
+          bpItemExplorer.type === "selectable" &&
+          bpItemExplorer.selectedHash === props.hash,
       })}
     >
       <SC.BlueprintItemInner>
@@ -198,7 +203,15 @@ function BlueprintItem(props: IBlueprintItemProps): JSX.Element {
                       />
                     </SC.RequiredItems>
                   )}
-                  {props.children}
+                  {!props.isBook && bpItemExplorer.type === "selectable" && (
+                    <SC.SelectRenderButton
+                      variant="alt"
+                      type="button"
+                      onClick={(e) => bpItemExplorer.onSelect(e, props.hash)}
+                    >
+                      Select render
+                    </SC.SelectRenderButton>
+                  )}
                 </SC.InnerContent>
               </SC.Info>
             </>
@@ -213,6 +226,7 @@ function BlueprintItem(props: IBlueprintItemProps): JSX.Element {
                 return (
                   <BlueprintItem
                     key={node.hash}
+                    hash={node.hash}
                     depth={props.depth + 1}
                     isBook={true}
                     title={node.label}
@@ -227,6 +241,7 @@ function BlueprintItem(props: IBlueprintItemProps): JSX.Element {
               return (
                 <BlueprintItem
                   key={node.hash}
+                  hash={node.hash}
                   depth={props.depth + 1}
                   isBook={false}
                   title={node.label}

--- a/frontend/components/ui/BlueprintItem/blueprint-item.styles.tsx
+++ b/frontend/components/ui/BlueprintItem/blueprint-item.styles.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components"
 import { getTypo } from "../../../design/helpers/typo"
 import { COLOR } from "../../../design/tokens/color"
 import { ETypo } from "../../../design/tokens/typo"
+import Button from "../Button"
 import { ButtonWrapper } from "../Button/button.styles"
 import Stacker from "../Stacker"
 
@@ -129,4 +130,9 @@ export const Subtitle = styled.h3`
   ${getTypo(ETypo.METADATA_TITLE)};
   font-size: 16px;
   margin-top: 0;
+`
+
+export const SelectRenderButton = styled(Button)`
+  margin-top: 8px;
+  align-self: flex-end;
 `

--- a/frontend/components/ui/BlueprintItem/blueprint-item.styles.tsx
+++ b/frontend/components/ui/BlueprintItem/blueprint-item.styles.tsx
@@ -105,6 +105,7 @@ export const Expand = styled.button`
   color: ${COLOR.LINK};
   margin-left: auto !important;
   cursor: pointer;
+  flex: 0 0 auto;
 
   &:hover {
     color: ${lighten(0.05, COLOR.LINK)};

--- a/frontend/components/ui/BlueprintItem/blueprint-item.styles.tsx
+++ b/frontend/components/ui/BlueprintItem/blueprint-item.styles.tsx
@@ -13,7 +13,7 @@ export const BlueprintItemWrapper = styled.div<{ depth: number }>`
   flex-direction: column;
   justify-content: flex-end;
   overflow: hidden;
-  margin-left: ${(props) => props.depth * 40}px;
+  margin-left: ${(props) => (props.depth > 0 ? 40 : 0)}px;
 `
 
 export const BlueprintItemInner = styled.div``

--- a/frontend/components/ui/BlueprintItemExplorer/blueprint-item-explorer.component.tsx
+++ b/frontend/components/ui/BlueprintItemExplorer/blueprint-item-explorer.component.tsx
@@ -1,0 +1,84 @@
+import React from "react"
+import { IBookPayload, IFullPayload } from "../../../types/models"
+import { isBook } from "../../../utils/build"
+import BlueprintItem from "../BlueprintItem"
+import BlueprintItemExplorerContext, {
+  IBlueprintItemExplorerContext,
+} from "./blueprint-item-explorer.provider"
+
+interface IBaseBlueprintItemExplorerProps {
+  children: IBookPayload["children"]
+}
+
+interface IBlueprintItemExplorerPropsReadonly
+  extends IBaseBlueprintItemExplorerProps {
+  type: "readOnly"
+}
+
+interface IBlueprintItemExplorerPropsSelectable
+  extends IBaseBlueprintItemExplorerProps {
+  type: "selectable"
+  onSelect: (e: React.MouseEvent, hash: IFullPayload["hash"]) => void
+  selectedHash: IFullPayload["hash"] | null
+}
+
+type IBlueprintItemExplorerProps =
+  | IBlueprintItemExplorerPropsReadonly
+  | IBlueprintItemExplorerPropsSelectable
+
+function BlueprintItemExplorer(
+  props: IBlueprintItemExplorerProps
+): JSX.Element {
+  const createContextValue = (): IBlueprintItemExplorerContext => {
+    if (props.type === "readOnly") {
+      return {
+        type: "readOnly",
+      }
+    }
+
+    return {
+      type: "selectable",
+      onSelect: props.onSelect,
+      selectedHash: props.selectedHash,
+    }
+  }
+
+  return (
+    <BlueprintItemExplorerContext.Provider value={createContextValue()}>
+      {props.children.map((bp) => {
+        if (isBook(bp)) {
+          return (
+            <BlueprintItem
+              key={bp.hash}
+              hash={bp.hash}
+              depth={0}
+              isBook={true}
+              title={bp.label}
+              icons={bp.icons}
+              description={bp.description}
+              image={bp._links?.rendering_thumb}
+              nodes={bp.children}
+            />
+          )
+        }
+
+        return (
+          <BlueprintItem
+            key={bp.hash}
+            hash={bp.hash}
+            depth={0}
+            isBook={false}
+            title={bp.label}
+            icons={bp.icons}
+            description={bp.description}
+            image={bp._links?.rendering_thumb}
+            entities={bp.entities}
+            tiles={bp.tiles}
+          />
+        )
+      })}
+    </BlueprintItemExplorerContext.Provider>
+  )
+}
+
+export default BlueprintItemExplorer

--- a/frontend/components/ui/BlueprintItemExplorer/blueprint-item-explorer.provider.tsx
+++ b/frontend/components/ui/BlueprintItemExplorer/blueprint-item-explorer.provider.tsx
@@ -1,0 +1,32 @@
+import React, { useContext } from "react"
+import { IFullPayload } from "../../../types/models"
+
+interface IBlueprintItemExplorerContextSelectable {
+  type: "selectable"
+  onSelect: (e: React.MouseEvent, hash: IFullPayload["hash"]) => void
+  selectedHash: IFullPayload["hash"] | null
+}
+
+interface IBlueprintItemExplorerContextReadonly {
+  type: "readOnly"
+}
+
+export type IBlueprintItemExplorerContext =
+  | IBlueprintItemExplorerContextSelectable
+  | IBlueprintItemExplorerContextReadonly
+
+const BlueprintItemExplorerContext = React.createContext<IBlueprintItemExplorerContext | null>(
+  null
+)
+
+export const useBlueprintItemExplorer = () => {
+  const context = useContext(BlueprintItemExplorerContext)
+
+  if (!context) {
+    throw "Missing BlueprintItemExplorerContext"
+  }
+
+  return context
+}
+
+export default BlueprintItemExplorerContext

--- a/frontend/components/ui/BlueprintItemExplorer/index.ts
+++ b/frontend/components/ui/BlueprintItemExplorer/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./blueprint-item-explorer.component"


### PR DESCRIPTION
Contains a few bugfixes and QoL on blueprint items:

- Previously, only the first level of items would show a "select render" button
- The "expand" would collapse given a long-ish title
- The indentation across multiple levels was wrong
- Remove the "raw", "view in editor", and "copy to clipboard" buttons when creating a blueprint

Notably, was forced to encapsulate rendering of the blueprint items into a new component providing context to items via the Context API.

closes #534