### PR TITLE
refact: switch to rich text parsing

### DIFF
--- a/frontend/components/ui/ItemIcon/item-icon.component.tsx
+++ b/frontend/components/ui/ItemIcon/item-icon.component.tsx
@@ -14,6 +14,7 @@ const ItemIcon: React.FC<IItemIconProps> = (props) => {
   return (
     <SC.ItemIconWrapper
       {...props}
+      data-testid="item-icon"
       src={`${publicRuntimeConfig.cdnUrl}/icon/64/${props.type}/${props.name}.png`}
     />
   )

--- a/frontend/components/ui/WithIcons/__tests__/__snapshots__/with-icons.test.tsx.snap
+++ b/frontend/components/ui/WithIcons/__tests__/__snapshots__/with-icons.test.tsx.snap
@@ -1,0 +1,48 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<WithIcons /> parses a title with item icon 1`] = `
+<div>
+  <span
+    class="with-iconsstyles__WithIconsWrapper-z8o2sl-0 iAJRvc"
+  >
+     
+    <img
+      class="item-iconstyles__ItemIconWrapper-sc-16iffik-0 llnkpE"
+      data-testid="item-icon"
+      name="transport-belt"
+      src="https://api.local.factorio.tech/assets/icon/64/item/transport-belt.png"
+      type="item"
+    />
+    <span>
+       build name
+    </span>
+  </span>
+</div>
+`;
+
+exports[`<WithIcons /> parses a title with multiple item icons 1`] = `
+<div>
+  <span
+    class="with-iconsstyles__WithIconsWrapper-z8o2sl-0 iAJRvc"
+  >
+     
+    <img
+      class="item-iconstyles__ItemIconWrapper-sc-16iffik-0 llnkpE"
+      data-testid="item-icon"
+      name="transport-belt"
+      src="https://api.local.factorio.tech/assets/icon/64/item/transport-belt.png"
+      type="item"
+    />
+    <span>
+       build name 
+    </span>
+    <img
+      class="item-iconstyles__ItemIconWrapper-sc-16iffik-0 llnkpE"
+      data-testid="item-icon"
+      name="fast-transport-belt"
+      src="https://api.local.factorio.tech/assets/icon/64/item/fast-transport-belt.png"
+      type="item"
+    />
+  </span>
+</div>
+`;

--- a/frontend/components/ui/WithIcons/__tests__/__snapshots__/with-icons.test.tsx.snap
+++ b/frontend/components/ui/WithIcons/__tests__/__snapshots__/with-icons.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`<WithIcons /> parses a title with item icon 1`] = `
       type="item"
     />
     <span>
-       build name
+      build name
     </span>
   </span>
 </div>
@@ -34,7 +34,7 @@ exports[`<WithIcons /> parses a title with multiple item icons 1`] = `
       type="item"
     />
     <span>
-       build name 
+      build name
     </span>
     <img
       class="item-iconstyles__ItemIconWrapper-sc-16iffik-0 llnkpE"

--- a/frontend/components/ui/WithIcons/__tests__/useParseRichText.test.ts
+++ b/frontend/components/ui/WithIcons/__tests__/useParseRichText.test.ts
@@ -2,6 +2,12 @@ import { renderHook } from "@testing-library/react-hooks"
 import useParseRichText from "../useParseRichText.hook"
 
 describe("useParseRichText", () => {
+  it("parses a string", () => {
+    const { result } = renderHook(() => useParseRichText("simple string"))
+
+    expect(result.current).toEqual([{ type: "text", value: "simple string" }])
+  })
+
   it("parses a single icon", () => {
     const { result } = renderHook(() =>
       useParseRichText("[item=stone-furnace]")
@@ -19,5 +25,57 @@ describe("useParseRichText", () => {
       { type: "item", value: "stone-furnace" },
       { type: "item", value: "transport-belt" },
     ])
+  })
+
+  it("parses a string + icon", () => {
+    const { result } = renderHook(() =>
+      useParseRichText("some text [item=stone-furnace]")
+    )
+
+    expect(result.current).toEqual([
+      { type: "text", value: "some text" },
+      { type: "item", value: "stone-furnace" },
+    ])
+  })
+
+  it("parses an icon + string", () => {
+    const { result } = renderHook(() =>
+      useParseRichText("[item=stone-furnace] some text")
+    )
+
+    expect(result.current).toEqual([
+      { type: "item", value: "stone-furnace" },
+      { type: "text", value: "some text" },
+    ])
+  })
+
+  it("parses an icon + string + icon", () => {
+    const { result } = renderHook(() =>
+      useParseRichText("[item=stone-furnace] some text [item=fast-inserter]")
+    )
+
+    expect(result.current).toEqual([
+      { type: "item", value: "stone-furnace" },
+      { type: "text", value: "some text" },
+      { type: "item", value: "fast-inserter" },
+    ])
+  })
+
+  it("parses a text + icon + text", () => {
+    const { result } = renderHook(() =>
+      useParseRichText("some text [item=stone-furnace] more text")
+    )
+
+    expect(result.current).toEqual([
+      { type: "text", value: "some text" },
+      { type: "item", value: "stone-furnace" },
+      { type: "text", value: "more text" },
+    ])
+  })
+
+  it("parses an empty string", () => {
+    const { result } = renderHook(() => useParseRichText(""))
+
+    expect(result.current).toEqual([])
   })
 })

--- a/frontend/components/ui/WithIcons/__tests__/useParseRichText.test.ts
+++ b/frontend/components/ui/WithIcons/__tests__/useParseRichText.test.ts
@@ -1,0 +1,23 @@
+import { renderHook } from "@testing-library/react-hooks"
+import useParseRichText from "../useParseRichText.hook"
+
+describe("useParseRichText", () => {
+  it("parses a single icon", () => {
+    const { result } = renderHook(() =>
+      useParseRichText("[item=stone-furnace]")
+    )
+
+    expect(result.current).toEqual([{ type: "item", value: "stone-furnace" }])
+  })
+
+  it("parses two icons", () => {
+    const { result } = renderHook(() =>
+      useParseRichText("[item=stone-furnace][item=transport-belt]")
+    )
+
+    expect(result.current).toEqual([
+      { type: "item", value: "stone-furnace" },
+      { type: "item", value: "transport-belt" },
+    ])
+  })
+})

--- a/frontend/components/ui/WithIcons/__tests__/with-icons.test.tsx
+++ b/frontend/components/ui/WithIcons/__tests__/with-icons.test.tsx
@@ -1,0 +1,59 @@
+import React from "react"
+import { render } from "@testing-library/react"
+import WithIcons from "../index"
+
+describe("<WithIcons />", () => {
+  it("parses a title with no icons", () => {
+    const { getByText } = render(<WithIcons input="build name" />)
+
+    expect(getByText("build name")).toBeTruthy()
+  })
+
+  it("returns a default title when passed an empty string", () => {
+    const { getByText } = render(<WithIcons input="" />)
+
+    expect(getByText("[unnamed]")).toBeTruthy()
+  })
+
+  it("renders a prefix", () => {
+    const { getByText } = render(
+      <WithIcons prefix={<div>prefix</div>} input="build name" />
+    )
+
+    expect(getByText("build name")).toBeTruthy()
+    expect(getByText("prefix")).toBeTruthy()
+  })
+
+  it("parses a title with item icon", () => {
+    const { container, getByText, getAllByTestId } = render(
+      <WithIcons input="[item=transport-belt] build name" />
+    )
+
+    const icons = getAllByTestId("item-icon") as HTMLImageElement[]
+
+    expect(icons).toHaveLength(1)
+    expect(icons[0].src).toBe(
+      "https://api.local.factorio.tech/assets/icon/64/item/transport-belt.png"
+    )
+    expect(getByText("build name")).toBeTruthy()
+    expect(container).toMatchSnapshot()
+  })
+
+  it("parses a title with multiple item icons", () => {
+    const { container, getByText, getAllByTestId } = render(
+      <WithIcons input="[item=transport-belt] build name [item=fast-transport-belt]" />
+    )
+
+    const icons = getAllByTestId("item-icon") as HTMLImageElement[]
+
+    expect(icons).toHaveLength(2)
+    expect(icons[0].src).toBe(
+      "https://api.local.factorio.tech/assets/icon/64/item/transport-belt.png"
+    )
+    expect(icons[1].src).toBe(
+      "https://api.local.factorio.tech/assets/icon/64/item/fast-transport-belt.png"
+    )
+    expect(getByText("build name")).toBeTruthy()
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/frontend/components/ui/WithIcons/useParseRichText.hook.ts
+++ b/frontend/components/ui/WithIcons/useParseRichText.hook.ts
@@ -5,40 +5,62 @@ interface IParsedRichTextNode<T = "item" | "text"> {
 
 function parseItem(
   text: string
-): { text: IParsedRichTextNode<"item"> | null; rest: string } {
+): { part: IParsedRichTextNode<"item"> | null; rest: string } {
   const itemRegex = new RegExp(/(\[(item)=([a-z-]+)\])/)
   const result = text.match(itemRegex)
 
   if (!result) {
-    return { text: null, rest: text }
+    return { part: null, rest: text }
   }
 
   if (result[2] === "item" && result[3]) {
     const rest = text.replace(result[1], "")
-    return { text: { type: "item", value: result[3] }, rest }
+    return { part: { type: "item", value: result[3] }, rest }
   }
 
-  return { text: null, rest: text }
+  return { part: null, rest: text }
+}
+
+function parseText(
+  text: string
+): { part: IParsedRichTextNode<"text"> | null; rest: string } {
+  const itemRegex = new RegExp(/(\[(item)=([a-z-]+)\])/)
+  const result = text.match(itemRegex)
+
+  if (!result && text) {
+    return { part: { type: "text", value: text.trim() }, rest: "" }
+  }
+
+  if (!result) {
+    return { part: null, rest: text }
+  }
+
+  const index = text.indexOf(result[1])
+
+  const rest = text.slice(index)
+  const value = text.replace(rest, "")
+
+  return { part: { type: "text", value: value.trim() }, rest }
 }
 
 function useParseRichText(text: string): IParsedRichTextNode[] {
   const parts: IParsedRichTextNode[] = []
   let rest = ""
 
-  const initialParse = parseItem(text)
+  const initialParse = text.startsWith("[") ? parseItem(text) : parseText(text)
 
-  if (!initialParse.text) {
+  if (!initialParse.part) {
     return []
   }
 
-  parts.push(initialParse.text)
+  parts.push(initialParse.part)
   rest = initialParse.rest
 
   while (rest !== "") {
-    const parse = parseItem(rest)
+    const parse = rest.startsWith("[") ? parseItem(rest) : parseText(rest)
 
-    if (parse.text) {
-      parts.push(parse.text)
+    if (parse.part) {
+      parts.push(parse.part)
     }
 
     rest = parse.rest

--- a/frontend/components/ui/WithIcons/useParseRichText.hook.ts
+++ b/frontend/components/ui/WithIcons/useParseRichText.hook.ts
@@ -1,0 +1,50 @@
+interface IParsedRichTextNode<T = "item" | "text"> {
+  type: T
+  value: string
+}
+
+function parseItem(
+  text: string
+): { text: IParsedRichTextNode<"item"> | null; rest: string } {
+  const itemRegex = new RegExp(/(\[(item)=([a-z-]+)\])/)
+  const result = text.match(itemRegex)
+
+  if (!result) {
+    return { text: null, rest: text }
+  }
+
+  if (result[2] === "item" && result[3]) {
+    const rest = text.replace(result[1], "")
+    return { text: { type: "item", value: result[3] }, rest }
+  }
+
+  return { text: null, rest: text }
+}
+
+function useParseRichText(text: string): IParsedRichTextNode[] {
+  const parts: IParsedRichTextNode[] = []
+  let rest = ""
+
+  const initialParse = parseItem(text)
+
+  if (!initialParse.text) {
+    return []
+  }
+
+  parts.push(initialParse.text)
+  rest = initialParse.rest
+
+  while (rest !== "") {
+    const parse = parseItem(rest)
+
+    if (parse.text) {
+      parts.push(parse.text)
+    }
+
+    rest = parse.rest
+  }
+
+  return parts
+}
+
+export default useParseRichText

--- a/frontend/components/ui/WithIcons/with-icons.component.tsx
+++ b/frontend/components/ui/WithIcons/with-icons.component.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import ItemIcon from "../ItemIcon"
+import useParseRichText from "./useParseRichText.hook"
 import * as SC from "./with-icons.styles"
 
 interface IWithIcons {
@@ -8,26 +9,19 @@ interface IWithIcons {
 }
 
 function WithIcons(props: IWithIcons): JSX.Element {
+  const parts = useParseRichText(props.input)
+
   const formatted = React.useMemo(() => {
     if (!props.input) {
       return "[unnamed]"
     }
 
-    const regex = new RegExp(/(\[item=[A-z-]+\])/, "gi")
-    const itemRegex = new RegExp(/\[item=([A-z-]+)\]/, "i")
-    const parts = props.input.split(regex).filter(Boolean)
-
     return parts.map((part, index) => {
-      if (!part.match(regex)) {
-        return <span key={index}>{part}</span>
+      if (part.type === "text") {
+        return <span key={index}>{part.value}</span>
       }
 
-      const match = part.match(itemRegex)
-      if (!match || !match[1]) {
-        return <span key={index}>{part}</span>
-      }
-
-      return <ItemIcon key={index} type="item" name={match[1]} />
+      return <ItemIcon key={index} type="item" name={part.value} />
     })
   }, [props.input])
 

--- a/frontend/jest.config.js
+++ b/frontend/jest.config.js
@@ -1,6 +1,7 @@
 /* global module */
 
 module.exports = {
+  setupFiles: ["<rootDir>/jest.setup.js"],
   testRegex: "/__tests__/.*.test.tsx?$",
-  testEnvironment: "node",
+  testEnvironment: "jsdom",
 }

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -1,0 +1,4 @@
+import { setConfig } from "next/config"
+import { publicRuntimeConfig } from "./next.config"
+
+setConfig({ publicRuntimeConfig })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.13.5",
     "@babel/plugin-transform-runtime": "^7.13.10",
+    "@testing-library/react": "^11.2.5",
     "@types/classnames": "^2.2.11",
     "@types/jest": "^26.0.21",
     "@types/json-form-data": "^1.7.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -49,6 +49,7 @@
     "@babel/plugin-proposal-decorators": "^7.13.5",
     "@babel/plugin-transform-runtime": "^7.13.10",
     "@testing-library/react": "^11.2.5",
+    "@testing-library/react-hooks": "^5.1.0",
     "@types/classnames": "^2.2.11",
     "@types/jest": "^26.0.21",
     "@types/json-form-data": "^1.7.0",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1575,6 +1575,18 @@
     lz-string "^1.4.4"
     pretty-format "^26.6.2"
 
+"@testing-library/react-hooks@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-5.1.0.tgz#6014b7536d0e9427a1e73ce1d073c49a6af5fb3b"
+  integrity sha512-ChRyyA14e0CeVkWGp24v8q/IiWUqH+B8daRx4lGZme4dsudmMNWz+Qo2Q2NzbD2O5rAVXh2hSbS/KTKeqHYhkw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@types/react" ">=16.9.0"
+    "@types/react-dom" ">=16.9.0"
+    "@types/react-test-renderer" ">=16.9.0"
+    filter-console "^0.1.1"
+    react-error-boundary "^3.1.0"
+
 "@testing-library/react@^11.2.5":
   version "11.2.5"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
@@ -1759,6 +1771,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-dom@>=16.9.0":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-17.0.3.tgz#7fdf37b8af9d6d40127137865bb3fff8871d7ee1"
+  integrity sha512-4NnJbCeWE+8YBzupn/YrJxZ8VnjcJq5iR1laqQ1vkpQgBiA7bwk0Rp24fxsdNinzJY2U+HHS4dJJDPdoMjdJ7w==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-native@*":
   version "0.64.0"
   resolved "https://registry.yarnpkg.com/@types/react-native/-/react-native-0.64.0.tgz#8c4aab67fca2197eacc73e403239be85c909d564"
@@ -1786,6 +1805,13 @@
     "@types/react-dom" "*"
     "@types/react-transition-group" "*"
 
+"@types/react-test-renderer@>=16.9.0":
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz#3120f7d1c157fba9df0118dae20cb0297ee0e06b"
+  integrity sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@*":
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.1.tgz#e1a3cb278df7f47f17b5082b1b3da17170bd44b1"
@@ -1793,7 +1819,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^17.0.3":
+"@types/react@*", "@types/react@>=16.9.0", "@types/react@^17.0.3":
   version "17.0.3"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.3.tgz#ba6e215368501ac3826951eef2904574c262cc79"
   integrity sha512-wYOUxIgs2HZZ0ACNiIayItyluADNbONl7kt8lkLjVK8IitMH5QMyAh75Fwhmo37r1m7L2JaFj03sIfxBVDvRAg==
@@ -3837,6 +3863,11 @@ fill-range@^7.0.1:
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
   dependencies:
     to-regex-range "^5.0.1"
+
+filter-console@^0.1.1:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/filter-console/-/filter-console-0.1.1.tgz#6242be28982bba7415bcc6db74a79f4a294fa67c"
+  integrity sha512-zrXoV1Uaz52DqPs+qEwNJWJFAWZpYJ47UNmpN9q4j+/EYsz85uV0DC9k8tRND5kYmoVzL0W+Y75q4Rg8sRJCdg==
 
 find-cache-dir@3.3.1:
   version "3.3.1"
@@ -6523,6 +6554,13 @@ react-dropzone@^11.3.1:
     attr-accept "^2.2.1"
     file-selector "^0.2.2"
     prop-types "^15.7.2"
+
+react-error-boundary@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-3.1.1.tgz#932c5ca5cbab8ec4fe37fd7b415aa5c3a47597e7"
+  integrity sha512-W3xCd9zXnanqrTUeViceufD3mIW8Ut29BUD+S2f0eO2XCOU8b6UrJfY46RDGe5lxCJzfe4j0yvIfh0RbTZhKJw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
 
 react-fast-compare@^2.0.1:
   version "2.0.4"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -31,7 +31,7 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.12.13":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13":
   version "7.12.13"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.12.13.tgz#dcfc826beef65e75c50e21d3837d7d95798dd658"
   integrity sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==
@@ -1561,6 +1561,33 @@
   dependencies:
     defer-to-connect "^2.0.0"
 
+"@testing-library/dom@^7.28.1":
+  version "7.30.0"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-7.30.0.tgz#53697851f7708a1448cc30b74a2ea056dd709cd6"
+  integrity sha512-v4GzWtltaiDE0yRikLlcLAfEiiK8+ptu6OuuIebm9GdC2XlZTNDPGEfM2UkEtnH7hr9TRq2sivT5EA9P1Oy7bw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^4.2.0"
+    aria-query "^4.2.2"
+    chalk "^4.1.0"
+    dom-accessibility-api "^0.5.4"
+    lz-string "^1.4.4"
+    pretty-format "^26.6.2"
+
+"@testing-library/react@^11.2.5":
+  version "11.2.5"
+  resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.2.5.tgz#ae1c36a66c7790ddb6662c416c27863d87818eb9"
+  integrity sha512-yEx7oIa/UWLe2F2dqK0FtMF9sJWNXD+2PPtp39BvE0Kh9MJ9Kl0HrZAgEuhUJR+Lx8Di6Xz+rKwSdEPY2UV8ZQ==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@testing-library/dom" "^7.28.1"
+
+"@types/aria-query@^4.2.0":
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-4.2.1.tgz#78b5433344e2f92e8b306c06a5622c50c245bf6b"
+  integrity sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.14"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
@@ -2623,7 +2650,7 @@ chalk@4.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.0.tgz#4e14870a618d9e2edd97dd8345fd9d9dc315646a"
   integrity sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
@@ -3188,6 +3215,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-accessibility-api@^0.5.4:
+  version "0.5.4"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.4.tgz#b06d059cdd4a4ad9a79275f9d414a5c126241166"
+  integrity sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
 
 dom-helpers@^3.3.1:
   version "3.4.0"
@@ -5401,6 +5433,11 @@ lru-cache@6.0.0, lru-cache@^6.0.0:
   integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
     yallist "^4.0.0"
+
+lz-string@^1.4.4:
+  version "1.4.4"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.4.4.tgz#c0d8eaf36059f705796e1e344811cf4c498d3a26"
+  integrity sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
 
 make-dir@^3.0.0, make-dir@^3.0.2:
   version "3.1.0"


### PR DESCRIPTION
This switches to a more flexible parsing of the Factorio rich text, including tests, to make it easier to iterate over.

The idea is to support #532 and #531, and possibly more in the future.

There are probably better ways to build a parser, so open to a refactor.
