### PR TITLE
feat(build form): improve tags selection counter

### DIFF
--- a/frontend/components/pages/BuildFormPage/step-1.component.tsx
+++ b/frontend/components/pages/BuildFormPage/step-1.component.tsx
@@ -82,14 +82,7 @@ const Step1: React.FC<IStep1Props> = (props) => {
         isBook: true,
         json,
         data: getBlueprintData(json),
-        tags: json.blueprint_book.blueprints
-          .map((bp) => {
-            if (!isBlueprintItem(bp)) {
-              return []
-            }
-            return tagsFromHeuristics(bp.blueprint)
-          })
-          .reduce((acc, curr) => [...acc, ...curr], []),
+        tags: tagsFromHeuristics(json.blueprint_book),
       }
     } else {
       return {

--- a/frontend/components/pages/BuildFormPage/step-2-data.component.tsx
+++ b/frontend/components/pages/BuildFormPage/step-2-data.component.tsx
@@ -44,7 +44,9 @@ const CollapsableGroup = (props: ICollapsableGroupProps): JSX.Element => {
           <SC.GroupTitle type="button" onClick={expand}>
             <Caret inverted={collapsed} />
             {startCase(props.group)}
-            <SC.GroupCount>{selectedTags.length}</SC.GroupCount>
+            {selectedTags.length > 0 && (
+              <SC.GroupCount>{selectedTags.length}</SC.GroupCount>
+            )}
           </SC.GroupTitle>
         }
       >

--- a/frontend/utils/blueprint-heuristics.ts
+++ b/frontend/utils/blueprint-heuristics.ts
@@ -1,4 +1,6 @@
-import { IBlueprint, IBlueprintEntity } from "../types"
+import uniq from "lodash/uniq"
+import { IBlueprint, IBlueprintBook, IBlueprintEntity } from "../types"
+import { isBlueprintItem } from "./blueprint"
 
 interface IComputedHeuristic {
   value: boolean
@@ -102,7 +104,7 @@ const LATE_GAME_ENTITIES = [
 ]
 const END_GAME_ENTITIES = ["rocket-silo"]
 
-export function tagsFromHeuristics(blueprint: IBlueprint): string[] {
+function parse(blueprint: IBlueprint): string[] {
   const tags: string[] = []
 
   // Belt tags
@@ -187,4 +189,25 @@ export function tagsFromHeuristics(blueprint: IBlueprint): string[] {
   }
 
   return tags
+}
+
+export function tagsFromHeuristics(
+  blueprintOrBook: IBlueprint | IBlueprintBook
+): string[] {
+  if (blueprintOrBook.type === "blueprint") {
+    const tags = parse(blueprintOrBook)
+
+    return uniq(tags)
+  }
+
+  const tags = blueprintOrBook.blueprints
+    .map((bp) => {
+      if (!isBlueprintItem(bp)) {
+        return []
+      }
+      return parse(bp.blueprint)
+    })
+    .reduce((acc, curr) => [...acc, ...curr], [])
+
+  return uniq(tags)
 }


### PR DESCRIPTION
1. Avoid showing counter without a selection (seeing a bunch of 0s was just more confusing), this aligns with the UX in the tags filtering on the main page.
2. Fix the incorrect number for blueprint books.

![image](https://user-images.githubusercontent.com/3461986/113791044-bcef4380-9710-11eb-90f6-47a21a091c80.png)
