### PR TITLE
fix: blueprint and books don't have a type

### DIFF
--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -76,11 +76,10 @@ export interface IDecodedBlueprintBookData {
 }
 
 export interface IBlueprint {
-  type: "blueprint"
+  item: "blueprint"
   icons?: Array<IBlueprintIcon>
   entities?: Array<IBlueprintEntity>
   tiles?: Array<IBlueprintTile>
-  item: string
   label: string
   description?: string
   version: number
@@ -110,7 +109,7 @@ interface IBookItemDeconstructionPlanner {
 export type TBookItem = IBookItemBlueprint | IBookItemDeconstructionPlanner
 
 export interface IBlueprintBook {
-  type: "blueprint-book"
+  item: "blueprint-book"
   blueprints: TBookItem[]
   icons?: Array<IBlueprintIcon>
   label: string

--- a/frontend/utils/blueprint-heuristics.ts
+++ b/frontend/utils/blueprint-heuristics.ts
@@ -194,7 +194,7 @@ function parse(blueprint: IBlueprint): string[] {
 export function tagsFromHeuristics(
   blueprintOrBook: IBlueprint | IBlueprintBook
 ): string[] {
-  if (blueprintOrBook.type === "blueprint") {
+  if (blueprintOrBook.item === "blueprint") {
     const tags = parse(blueprintOrBook)
 
     return uniq(tags)


### PR DESCRIPTION
Trying to access `blueprint.type` would crash the form.