### PR TITLE
perf: optimize homepage images to be max 300px

### DIFF
--- a/frontend/components/ui/BuildCard/build-card.component.tsx
+++ b/frontend/components/ui/BuildCard/build-card.component.tsx
@@ -53,6 +53,7 @@ function BuildCard({
             width={image.width}
             height={image.height}
             layout="responsive"
+            sizes="300px"
           />
         </SC.ImageWrapper>
         <SC.Content>


### PR DESCRIPTION
This will load 300px/600px retina images on the homepage to lighten the load.

300px is dummy for now, while somewhat accurate, another PR is coming to load the correct size, responsively.

Before:

![image](https://user-images.githubusercontent.com/3461986/116325953-5bf7e000-a791-11eb-96a1-cf59bb97cfe9.png)

First Contentful Paint 0.4 s
Time to Interactive 0.8 s
Speed Index 1.3 s
Largest Contentful Paint 2.4 s