### PR TITLE
perf: optimize images

### DIFF
--- a/frontend/components/pages/BuildPage/build-page.component.tsx
+++ b/frontend/components/pages/BuildPage/build-page.component.tsx
@@ -1,12 +1,11 @@
 import React, { useMemo } from "react"
 import { useToggle } from "react-use"
-import getConfig from "next/config"
-import Image from "next/image"
 import Link from "next/link"
 import { NextRouter } from "next/router"
 import { IFullBuild } from "../../../types/models"
 import { isBook } from "../../../utils/build"
 import BuildHeader from "../../ui/BuildHeader"
+import BuildImage from "../../ui/BuildImage"
 import Container from "../../ui/Container"
 import LayoutDefault from "../../ui/LayoutDefault"
 import Stacker from "../../ui/Stacker"
@@ -20,8 +19,6 @@ import DetailsTab from "./tabs/details-tab.component"
 import ImageMobileTab from "./tabs/image-mobile-tab.component"
 import RequiredItemsTab from "./tabs/required-items-tab.component"
 import usePayload from "./usePayload"
-
-const { publicRuntimeConfig } = getConfig()
 
 interface IBuildPageProps {
   build: IFullBuild
@@ -95,15 +92,9 @@ function BuildPage({ build, router }: IBuildPageProps): JSX.Element {
     <SC.BuildImage>
       {build._links.cover ? (
         <SC.ImageWrapper role="button" onClick={toggleZoomedImage}>
-          <Image
-            loader={({ src }) =>
-              `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=1326&format=jpg&quality=75`
-            }
-            src={build._links.cover.href}
-            alt=""
-            width={build._links.cover.width}
-            height={build._links.cover.height}
-            layout="responsive"
+          <BuildImage
+            image={build._links.cover}
+            forcedWidth={zoomedImage ? 1326 : 400}
           />
         </SC.ImageWrapper>
       ) : (

--- a/frontend/components/pages/BuildPage/build-page.component.tsx
+++ b/frontend/components/pages/BuildPage/build-page.component.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from "react"
 import { useToggle } from "react-use"
+import getConfig from "next/config"
 import Image from "next/image"
 import Link from "next/link"
 import { NextRouter } from "next/router"
@@ -19,6 +20,8 @@ import DetailsTab from "./tabs/details-tab.component"
 import ImageMobileTab from "./tabs/image-mobile-tab.component"
 import RequiredItemsTab from "./tabs/required-items-tab.component"
 import usePayload from "./usePayload"
+
+const { publicRuntimeConfig } = getConfig()
 
 interface IBuildPageProps {
   build: IFullBuild
@@ -93,6 +96,9 @@ function BuildPage({ build, router }: IBuildPageProps): JSX.Element {
       {build._links.cover ? (
         <SC.ImageWrapper role="button" onClick={toggleZoomedImage}>
           <Image
+            loader={({ src }) =>
+              `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=1326&format=jpg&quality=75`
+            }
             src={build._links.cover.href}
             alt=""
             width={build._links.cover.width}

--- a/frontend/components/pages/BuildPage/tabs/image-mobile-tab.component.tsx
+++ b/frontend/components/pages/BuildPage/tabs/image-mobile-tab.component.tsx
@@ -1,27 +1,15 @@
 import React from "react"
-import getConfig from "next/config"
-import Image from "next/image"
+import BuildImage from "../../../ui/BuildImage"
 import * as SC from "../build-page.styles"
 import { TTabComponent } from "../tabs.component"
 import Tab from "./tab.component"
-
-const { publicRuntimeConfig } = getConfig()
 
 const ImageMobileTab: TTabComponent = (props) => {
   return (
     <Tab {...props}>
       <SC.BuildImage>
         {props.build._links.cover ? (
-          <Image
-            loader={({ src }) =>
-              `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=700&format=jpg&quality=75`
-            }
-            src={props.build._links.cover.href}
-            alt=""
-            width={props.build._links.cover.width}
-            height={props.build._links.cover.height}
-            layout="responsive"
-          />
+          <BuildImage image={props.build._links.cover} forcedWidth={700} />
         ) : (
           "No image"
         )}

--- a/frontend/components/pages/BuildPage/tabs/image-mobile-tab.component.tsx
+++ b/frontend/components/pages/BuildPage/tabs/image-mobile-tab.component.tsx
@@ -1,8 +1,11 @@
 import React from "react"
+import getConfig from "next/config"
 import Image from "next/image"
 import * as SC from "../build-page.styles"
 import { TTabComponent } from "../tabs.component"
 import Tab from "./tab.component"
+
+const { publicRuntimeConfig } = getConfig()
 
 const ImageMobileTab: TTabComponent = (props) => {
   return (
@@ -10,6 +13,9 @@ const ImageMobileTab: TTabComponent = (props) => {
       <SC.BuildImage>
         {props.build._links.cover ? (
           <Image
+            loader={({ src }) =>
+              `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=700&format=jpg&quality=75`
+            }
             src={props.build._links.cover.href}
             alt=""
             width={props.build._links.cover.width}

--- a/frontend/components/ui/BuildCard/build-card.component.tsx
+++ b/frontend/components/ui/BuildCard/build-card.component.tsx
@@ -1,16 +1,13 @@
 import React from "react"
 import { usePress } from "@react-aria/interactions"
 import cx from "classnames"
-import getConfig from "next/config"
-import Image from "next/image"
 import Link from "next/link"
 import { useRouter } from "next/router"
 import { IThinBuild } from "../../../types/models"
 import BuildIcon from "../BuildIcon"
+import BuildImage from "../BuildImage"
 import RichText from "../RichText"
 import * as SC from "./build-card.styles"
-
-const { publicRuntimeConfig } = getConfig()
 
 interface IBuildCardProps {
   title: IThinBuild["title"]
@@ -50,17 +47,7 @@ function BuildCard({
         className={cx({ "is-pressed": isPressed })}
       >
         <SC.ImageWrapper>
-          <Image
-            loader={({ src }) =>
-              `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=400&format=jpg&quality=75`
-            }
-            src={image.href}
-            alt=""
-            width={image.width}
-            height={image.height}
-            layout="responsive"
-            sizes="300px"
-          />
+          <BuildImage image={image} forcedWidth={400} />
         </SC.ImageWrapper>
         <SC.Content>
           <SC.Title orientation="horizontal" gutter={8}>

--- a/frontend/components/ui/BuildImage/build-image.component.tsx
+++ b/frontend/components/ui/BuildImage/build-image.component.tsx
@@ -1,9 +1,6 @@
 import React from "react"
-import getConfig from "next/config"
 import Image from "next/image"
 import { IThinBuild } from "../../../types/models"
-
-const { publicRuntimeConfig } = getConfig()
 
 interface IBuildImageProps {
   image: IThinBuild["_links"]["cover"]
@@ -14,9 +11,7 @@ interface IBuildImageProps {
 function BuildImage({ image, forcedWidth }: IBuildImageProps): JSX.Element {
   return (
     <Image
-      loader={({ src }) =>
-        `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=${forcedWidth}&format=jpg&quality=75`
-      }
+      loader={({ src }) => `${src}?width=${forcedWidth}&format=jpg&quality=75`}
       src={image.href}
       alt=""
       width={image.width}

--- a/frontend/components/ui/BuildImage/build-image.component.tsx
+++ b/frontend/components/ui/BuildImage/build-image.component.tsx
@@ -1,0 +1,30 @@
+import React from "react"
+import getConfig from "next/config"
+import Image from "next/image"
+import { IThinBuild } from "../../../types/models"
+
+const { publicRuntimeConfig } = getConfig()
+
+interface IBuildImageProps {
+  image: IThinBuild["_links"]["cover"]
+  /* @temporary */
+  forcedWidth: number
+}
+
+function BuildImage({ image, forcedWidth }: IBuildImageProps): JSX.Element {
+  return (
+    <Image
+      loader={({ src }) =>
+        `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=${forcedWidth}&format=jpg&quality=75`
+      }
+      src={image.href}
+      alt=""
+      width={image.width}
+      height={image.height}
+      layout="responsive"
+      sizes="300px"
+    />
+  )
+}
+
+export default BuildImage

--- a/frontend/components/ui/BuildImage/index.ts
+++ b/frontend/components/ui/BuildImage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./build-image.component"

--- a/frontend/components/ui/BuildList/build-list.component.tsx
+++ b/frontend/components/ui/BuildList/build-list.component.tsx
@@ -1,17 +1,14 @@
 import * as React from "react"
 import { useState } from "react"
-import getConfig from "next/config"
-import Image from "next/image"
 import { useRouter } from "next/router"
 import Caret from "../../../icons/caret"
 import { IThinBuild } from "../../../types/models"
 import { formatDate, formatSince } from "../../../utils/date"
 import Avatar from "../Avatar"
+import BuildImage from "../BuildImage"
 import Stacker from "../Stacker"
 import Tooltip from "../Tooltip"
 import * as SC from "./build-list.styles"
-
-const { publicRuntimeConfig } = getConfig()
 
 interface IBuildListProps {
   items: IThinBuild[]
@@ -100,14 +97,13 @@ const BuildList: React.FC<IBuildListProps> = ({ items }) => {
               .map((item) => (
                 <tr key={item.slug}>
                   <td style={{ width: "1px" }}>
-                    <Image
-                      loader={({ src }) =>
-                        `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=64&format=jpg&quality=75`
-                      }
-                      src={item._links.cover.href}
-                      width={64}
-                      height={64}
-                      layout="fixed"
+                    <BuildImage
+                      image={{
+                        ...item._links.cover,
+                        width: 64,
+                        height: 64,
+                      }}
+                      forcedWidth={64}
                     />
                   </td>
                   <td>

--- a/frontend/components/ui/BuildList/build-list.component.tsx
+++ b/frontend/components/ui/BuildList/build-list.component.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { useState } from "react"
+import getConfig from "next/config"
 import Image from "next/image"
 import { useRouter } from "next/router"
 import Caret from "../../../icons/caret"
@@ -9,6 +10,8 @@ import Avatar from "../Avatar"
 import Stacker from "../Stacker"
 import Tooltip from "../Tooltip"
 import * as SC from "./build-list.styles"
+
+const { publicRuntimeConfig } = getConfig()
 
 interface IBuildListProps {
   items: IThinBuild[]
@@ -98,6 +101,9 @@ const BuildList: React.FC<IBuildListProps> = ({ items }) => {
                 <tr key={item.slug}>
                   <td style={{ width: "1px" }}>
                     <Image
+                      loader={({ src }) =>
+                        `${publicRuntimeConfig.apiUrl}/images/covers/${src}?width=64&format=jpg&quality=75`
+                      }
                       src={item._links.cover.href}
                       width={64}
                       height={64}


### PR DESCRIPTION
First step to use the optimized images everywhere that was using `next/image`, plus extracting it to its own component.