### PR TITLE
perf: move away from next/image, in-house responsive loading image within context

### DIFF
--- a/frontend/components/pages/BuildPage/build-page.component.tsx
+++ b/frontend/components/pages/BuildPage/build-page.component.tsx
@@ -92,10 +92,7 @@ function BuildPage({ build, router }: IBuildPageProps): JSX.Element {
     <SC.BuildImage>
       {build._links.cover ? (
         <SC.ImageWrapper role="button" onClick={toggleZoomedImage}>
-          <BuildImage
-            image={build._links.cover}
-            forcedWidth={zoomedImage ? 1326 : 400}
-          />
+          <BuildImage image={build._links.cover} />
         </SC.ImageWrapper>
       ) : (
         "No image"

--- a/frontend/components/pages/BuildPage/tabs/image-mobile-tab.component.tsx
+++ b/frontend/components/pages/BuildPage/tabs/image-mobile-tab.component.tsx
@@ -9,7 +9,7 @@ const ImageMobileTab: TTabComponent = (props) => {
     <Tab {...props}>
       <SC.BuildImage>
         {props.build._links.cover ? (
-          <BuildImage image={props.build._links.cover} forcedWidth={700} />
+          <BuildImage image={props.build._links.cover} />
         ) : (
           "No image"
         )}

--- a/frontend/components/ui/BuildCard/build-card.component.tsx
+++ b/frontend/components/ui/BuildCard/build-card.component.tsx
@@ -47,7 +47,7 @@ function BuildCard({
         className={cx({ "is-pressed": isPressed })}
       >
         <SC.ImageWrapper>
-          <BuildImage image={image} forcedWidth={400} />
+          <BuildImage image={image} />
         </SC.ImageWrapper>
         <SC.Content>
           <SC.Title orientation="horizontal" gutter={8}>

--- a/frontend/components/ui/BuildImage/build-image.component.tsx
+++ b/frontend/components/ui/BuildImage/build-image.component.tsx
@@ -1,24 +1,80 @@
-import React from "react"
-import Image from "next/image"
+import React, { useEffect, useMemo, useRef } from "react"
 import { IThinBuild } from "../../../types/models"
+import * as SC from "./build-image.styles"
+
+const generateSrcSet = (src: string) => {
+  return Array.from({ length: 20 })
+    .slice(1)
+    .map((_, index) => {
+      const width = index * 100
+      return `${src}?width=${width}&format=jpg&quality=75 ${width}w`
+    })
+    .join(", ")
+}
 
 interface IBuildImageProps {
   image: IThinBuild["_links"]["cover"]
-  /* @temporary */
-  forcedWidth: number
 }
 
-function BuildImage({ image, forcedWidth }: IBuildImageProps): JSX.Element {
+function BuildImage({ image }: IBuildImageProps): JSX.Element {
+  const imageRef = useRef<HTMLImageElement | null>(null)
+  const observerRef = useRef<ResizeObserver | null>(null)
+
+  const srcSet = useMemo(() => {
+    return generateSrcSet(image.href)
+  }, [image.href])
+
+  const handleMount = () => {
+    if (!imageRef.current) return
+    if (typeof window === "undefined") return
+
+    observerRef.current = new ResizeObserver(
+      ([entry]: ResizeObserverEntry[]) => {
+        requestAnimationFrame(() => {
+          const { width } = entry.contentRect
+          if (!imageRef.current) return
+
+          const imgEl = imageRef.current
+          const widthToRender = Math.ceil(Math.floor(width) / 100) * 100
+
+          if (imgEl.sizes !== `${widthToRender}px`) {
+            imgEl.sizes = `${widthToRender}px`
+          }
+
+          if (imgEl.srcset !== srcSet) {
+            imgEl.srcset = srcSet
+          }
+        })
+      }
+    )
+
+    observerRef.current.observe(imageRef.current)
+  }
+
+  useEffect(() => {
+    if (!imageRef.current) return
+
+    handleMount()
+
+    return () => {
+      observerRef.current?.disconnect()
+    }
+  }, [])
+
   return (
-    <Image
-      loader={({ src }) => `${src}?width=${forcedWidth}&format=jpg&quality=75`}
-      src={image.href}
-      alt=""
-      width={image.width}
-      height={image.height}
-      layout="responsive"
-      sizes="300px"
-    />
+    <SC.OuterWrapper
+      style={{ "--ratio": image.width / image.height } as React.CSSProperties}
+    >
+      <SC.InnerWrapper>
+        <img
+          // TODO: use the upcoming blur as the default image
+          src={`${image.href}?width=500&format=jpg&quality=75`}
+          ref={imageRef}
+          style={{ width: "100%", height: "auto" }}
+          alt=""
+        />
+      </SC.InnerWrapper>
+    </SC.OuterWrapper>
   )
 }
 

--- a/frontend/components/ui/BuildImage/build-image.styles.tsx
+++ b/frontend/components/ui/BuildImage/build-image.styles.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components"
+
+export const OuterWrapper = styled.div`
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: calc((1 / var(--ratio)) * 100%);
+`
+
+export const InnerWrapper = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+`

--- a/frontend/components/ui/BuildList/build-list.component.tsx
+++ b/frontend/components/ui/BuildList/build-list.component.tsx
@@ -103,7 +103,6 @@ const BuildList: React.FC<IBuildListProps> = ({ items }) => {
                         width: 64,
                         height: 64,
                       }}
-                      forcedWidth={64}
                     />
                   </td>
                   <td>


### PR DESCRIPTION
This moves away from `next/image`, as it can only handle responsive images as per the viewport width, and not the current context the image resides in.