### PR TITLE
fix: update rendering URL preventing selecting a cover

### DIFF
--- a/frontend/components/pages/BuildFormPage/useCanSave.ts
+++ b/frontend/components/pages/BuildFormPage/useCanSave.ts
@@ -19,7 +19,7 @@ function useCanSave(
     }
 
     return formikProps.values.cover.hash
-      ? `${publicRuntimeConfig.apiUrl}/payloads/${formikProps.values.cover.hash}/rendering/thumb`
+      ? `${publicRuntimeConfig.apiUrl}/images/renderings/${formikProps.values.cover.hash}`
       : null
   }, [
     payloadData._links.rendering?.href,


### PR DESCRIPTION
Previous URL would always lead to a 404.