### PR TITLE
fix(a11y): improve inputs focus

### DIFF
--- a/frontend/components/form/Checkbox/checkbox.styles.tsx
+++ b/frontend/components/form/Checkbox/checkbox.styles.tsx
@@ -50,7 +50,7 @@ export const CheckboxWrapper = styled("div", {
   },
 
   [`&:focus-within ${Square}`]: {
-    boxShadow: "0 0 0 3px $focused",
+    boxShadow: "0 0 0 3px $colors$focused",
     outline: "none",
   },
 

--- a/frontend/components/form/Input/input.component.tsx
+++ b/frontend/components/form/Input/input.component.tsx
@@ -1,5 +1,4 @@
-import { useState } from "react"
-import cx from "classnames"
+import React from "react"
 import * as S from "./input.styles"
 
 interface ITextProps extends React.InputHTMLAttributes<HTMLInputElement> {
@@ -36,22 +35,21 @@ const Text: React.FC<ITextProps> = ({
   onKeyPress,
   ...restProps
 }) => {
-  const [focused, setFocused] = useState(false)
+  const inputRef = React.useRef<HTMLInputElement>(null)
 
-  function setFocus(): void {
-    setFocused(true)
-  }
-
-  function clearFocus(): void {
-    setFocused(false)
+  function focus(): void {
+    if (inputRef.current) {
+      inputRef.current.focus()
+    }
   }
 
   return (
-    <S.StyledInputWrapper className={cx({ "is-focused": focused })}>
+    <S.StyledInputWrapper onClick={focus}>
       {customPrefix && <S.Prefix>{customPrefix}</S.Prefix>}
       {icon}
       <S.StyledInput
         {...restProps}
+        ref={inputRef}
         id={id}
         name={name}
         value={value}
@@ -60,8 +58,6 @@ const Text: React.FC<ITextProps> = ({
         readOnly={readOnly}
         onChange={onChange}
         onKeyPress={onKeyPress}
-        onFocus={setFocus}
-        onBlur={clearFocus}
       />
     </S.StyledInputWrapper>
   )

--- a/frontend/components/form/Radio/radio.styles.tsx
+++ b/frontend/components/form/Radio/radio.styles.tsx
@@ -49,7 +49,7 @@ export const RadioWrapper = styled("div", {
   },
 
   [`&:focus-within ${Square}`]: {
-    boxShadow: "0 0 0 3px $focused",
+    boxShadow: "0 0 0 3px $colors$focused",
     outline: "none",
   },
 


### PR DESCRIPTION
The input wasn't getting focused properly when wrapped in a sub-component, and the checkbox/radio weren't visually focused.